### PR TITLE
fix(css): fixes styling of inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -422,6 +422,7 @@ textarea[disabled] {
 input[type="text"],
 input[type="password"],
 input[type="file"],
+input[type="number"],
 select {
   background: #212121 none repeat scroll 0 0;
   border: 1px solid #313131;
@@ -431,13 +432,15 @@ select {
 input[type="text"][disabled],
 input[type="password"][disabled],
 input[type="file"][disabled],
+input[type="number"],
 select[disabled] {
   background: #212121 none repeat scroll 0 0;
   border: 1px solid #313131;
   color: black;
 }
 
-input.Button {
+input.Button0,
+input[type="button"] {
   background: #222 none repeat scroll 0 0;
   border: 1px solid #333;
   border-radius: 3px;
@@ -453,7 +456,9 @@ input.Button {
 }
 
 input.Button:hover,
-input.Button:focus {
+input.Button:focus,
+input[type="button"]:hover
+input[type="button"]:focus {
   background: #3a3a3a none repeat scroll 0 0;
   text-shadow: 0 0 4px #999;
   color: #999;
@@ -964,6 +969,10 @@ div#t div#ind {
 
 span#loadimg {
   background: transparent url(./images/ajax-loader.png) no-repeat center center;
+}
+
+#fltlist li {
+    margin: 3px;
 }
 
 /*Scrollbars*/

--- a/style.css
+++ b/style.css
@@ -440,7 +440,8 @@ select[disabled] {
 }
 
 input.Button0,
-input[type="button"] {
+input[type="button"],
+input.Button {
   background: #222 none repeat scroll 0 0;
   border: 1px solid #333;
   border-radius: 3px;

--- a/style.css
+++ b/style.css
@@ -432,7 +432,7 @@ select {
 input[type="text"][disabled],
 input[type="password"][disabled],
 input[type="file"][disabled],
-input[type="number"],
+input[type="number"][disabled],
 select[disabled] {
   background: #212121 none repeat scroll 0 0;
   border: 1px solid #313131;


### PR DESCRIPTION
## Description
Thanks, for updating this. I found a few nitpicks.

* Some buttons use `<input type="button">` instead of `<button>` , added an extra selector to have them be dark themed

![image](https://user-images.githubusercontent.com/9259833/215937391-0a868f09-1fb5-464d-8428-3a9246112d37.png)

* Some inputs now use `type="number"` in the preferences so we need to add an additional selector to have the "Update GUI every" and "Request timeout" inputs be dark

![image](https://user-images.githubusercontent.com/9259833/215937230-04ea31a6-2242-41a8-a70e-ab12184b2975.png)


* Added margin to the list items since the rss feed name input focus is being overlapped

![image](https://user-images.githubusercontent.com/9259833/215937900-5ccfbb27-0ae5-47e0-824b-9eba33d7d8c9.png)
